### PR TITLE
Fix 5.10 kernel version upgrade to support live kernel patching

### DIFF
--- a/scripts/kernel.sh
+++ b/scripts/kernel.sh
@@ -15,9 +15,12 @@ case $(uname -r) in
         ;;
     *)
         echo "use linux kernel 5.10"
+        if yum versionlock | grep 'kernel'; then
+            yum versionlock delete 'kernel'
+        fi
         amazon-linux-extras disable kernel-5.4
         amazon-linux-extras install kernel-5.10 -y
-        rpm -qa | grep kernel
+        rpm -qa | grep 'kernel'
 
         echo "rebooting the instance"
         reboot


### PR DESCRIPTION
Update `scripts/kernel.sh` which sets the kernel to `5.10` with packer.

NOTE: needs rebasing, should be adding 1 commit to #6 

Updates: https://github.com/ConsultingMD/amazon-eks-custom-amis/pull/3/