### PR TITLE
Use separate EBS Volumes for /var, /home folders (EKS 1.24+)

### DIFF
--- a/scripts/cis-docker.sh
+++ b/scripts/cis-docker.sh
@@ -23,7 +23,7 @@ echo "1.1.2 - ensure that the version of Docker is up to date"
 yum -y update docker
 
 echo "1.2.1 - ensure a separate partition for containers has been created"
-grep '/var/lib/docker\s' /proc/mounts
+#grep '/var/lib/docker\s' /proc/mounts
 
 echo "1.2.2 - ensure only trusted users are allowed to control Docker daemon"
 getent group docker

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -4,14 +4,44 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
-variable "data_volume_size" {
-  description = "Size of the AMI data EBS volume"
-  type        = number
-  default     = 50
+variable "eks_version" {
+  description = "The EKS cluster version associated with the AMI created"
+  type        = string
+  default     = "1.22"
 }
 
 variable "root_volume_size" {
   description = "Size of the AMI root EBS volume"
+  type        = number
+  default     = 4
+}
+
+variable "home_volume_size" {
+  description = "Size of the AMI /home EBS volume"
+  type        = number
+  default     = 1
+}
+
+variable "var_volume_size" {
+  description = "Size of the AMI /var EBS volume"
+  type        = number
+  default     = 4
+}
+
+variable "varlog_volume_size" {
+  description = "Size of the AMI /var/log EBS volume"
+  type        = number
+  default     = 1
+}
+
+variable "varlogaudit_volume_size" {
+  description = "Size of the AMI /var/log/audit EBS volume"
+  type        = number
+  default     = 1
+}
+
+variable "varlibcontainerd_volume_size" {
+  description = "Size of the AMI /var/lib/containerd EBS volume"
   type        = number
   default     = 10
 }
@@ -32,12 +62,6 @@ variable "region_kms_key_ids" {
   description = "Regions to copy the ami to, along with the custom kms key id (alias or arn) to use for encryption for that region."
   type        = map(string)
   default     = null
-}
-
-variable "eks_version" {
-  description = "The EKS cluster version associated with the AMI created"
-  type        = string
-  default     = "1.22"
 }
 
 variable "http_proxy" {


### PR DESCRIPTION
Updates non-root partitioned EBS Volumes into multiple volumes that can be resized.

Adds `/var/lib/cloud/scripts/per-boot/resize-disks.sh` to resize the non root EBS Volume XFS Filesystems on launch.

NOTE: needs rebase after https://github.com/ConsultingMD/amazon-eks-custom-amis/pull/1