### PR TITLE
auditd logs fill too fast (EKS 1.24+)

### DIFF
--- a/scripts/cis-docker.sh
+++ b/scripts/cis-docker.sh
@@ -33,7 +33,7 @@ echo "-w /usr/bin/dockerd -k docker" >> /etc/audit/rules.d/docker.rules
 echo "-w /usr/bin/docker -k docker" >> /etc/audit/rules.d/docker.rules
 
 echo "1.2.4 - 1.2.12 - ensure auditing is configured for Docker files and directories"
-echo "-w /var/lib/docker -k docker" >> /etc/audit/rules.d/docker.rules
+#echo "-w /var/lib/docker -k docker" >> /etc/audit/rules.d/docker.rules
 echo "-w /etc/docker -k docker" >> /etc/audit/rules.d/docker.rules
 echo "-w /etc/default/docker -k docker" >> /etc/audit/rules.d/docker.rules
 echo "-w /etc/sysconfig/docker -k docker" >> /etc/audit/rules.d/docker.rules


### PR DESCRIPTION
Items:
* disabled auditd rules
  * `-w /var/lib/docker -p rwxa -k docker`

NOTE: needs rebase after #9