### PR TITLE
Skip hardening docker (EKS 1.25+)

### DIFF
--- a/amazon-eks-al2.pkr.hcl
+++ b/amazon-eks-al2.pkr.hcl
@@ -148,7 +148,6 @@ build {
 
     scripts = [
       "scripts/cis-benchmark.sh",
-      "scripts/cis-docker.sh",
       "scripts/cis-eks.sh",
       "scripts/cleanup.sh",
     ]


### PR DESCRIPTION
Items:
* EKS 1.25+ doesn't have docker engine installed in the official EKS AL2 base AMI - disable `scripts/cis-docker.sh`

NOTE: needs rebase after https://github.com/ConsultingMD/amazon-eks-custom-amis/pull/11